### PR TITLE
Fix parsing error on python_requires >=3.0.* by simplifying to >=3

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -319,7 +319,7 @@ setup(
     # package_dir={'':'src'},
 
 
-    python_requires  = '>3.0, <4',
+    python_requires  = '>=3, <4',
     install_requires = [],  # Optional
     # https://packaging.python.org/discussions/install-requires-vs-requirements/
 


### PR DESCRIPTION
Under certain circumstances the existing python_requires string fails out the parser and causes the pip install to fail. Simplifying it should fix that. 
![Screenshot 2023-04-17 at 5 01 24 PM](https://user-images.githubusercontent.com/11711101/232610274-34c33e09-2fb7-4b05-8b1a-cb76ba17504b.png)
